### PR TITLE
Warn if building for an unsupported architecture

### DIFF
--- a/lib/spack/spack/build_systems/rocm.py
+++ b/lib/spack/spack/build_systems/rocm.py
@@ -90,9 +90,10 @@ class ROCmPackage(PackageBase):
     # https://llvm.org/docs/AMDGPUUsage.html
     # Possible architectures
     amdgpu_targets = (
-        'gfx701', 'gfx801', 'gfx802', 'gfx803',
-        'gfx900', 'gfx906', 'gfx908', 'gfx90a', 'gfx1010',
-        'gfx1011', 'gfx1012'
+        'gfx701', 'gfx801', 'gfx802', 'gfx803', 'gfx900',
+        'gfx906', 'gfx908', 'gfx90a',
+        'gfx906:xnack-', 'gfx908:xnack-', 'gfx90a:xnack-', 'gfx90a:xnack+',
+        'gfx1010', 'gfx1011', 'gfx1012', 'gfx1030',
     )
 
     variant('rocm', default=False, description='Enable ROCm support')

--- a/var/spack/repos/builtin/packages/rocblas/package.py
+++ b/var/spack/repos/builtin/packages/rocblas/package.py
@@ -5,6 +5,7 @@
 
 
 from spack import *
+from spack.build_systems.rocm import ROCmPackage
 
 
 class Rocblas(CMakePackage):
@@ -31,10 +32,7 @@ class Rocblas(CMakePackage):
     version('3.7.0', sha256='9425db5f8e8b6f7fb172d09e2a360025b63a4e54414607709efc5acb28819642', deprecated=True)
     version('3.5.0', sha256='8560fabef7f13e8d67da997de2295399f6ec595edfd77e452978c140d5f936f0', deprecated=True)
 
-    amdgpu_targets = ('gfx906', 'gfx908', 'gfx803', 'gfx900',
-                      'gfx906:xnack-', 'gfx908:xnack-', 'gfx90a:xnack+',
-                      'gfx90a:xnack-', 'gfx1010', 'gfx1011',
-                      'gfx1012', 'gfx1030')
+    amdgpu_targets = ROCmPackage.amdgpu_targets
 
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('tensile', default=True, description='Use Tensile as a backend')

--- a/var/spack/repos/builtin/packages/rocsolver/package.py
+++ b/var/spack/repos/builtin/packages/rocsolver/package.py
@@ -6,6 +6,7 @@
 import itertools
 
 from spack import *
+from spack.build_systems.rocm import ROCmPackage
 
 
 class Rocsolver(CMakePackage):
@@ -18,10 +19,8 @@ class Rocsolver(CMakePackage):
 
     maintainers = ['srekolam', 'arjun-raj-kuppala', 'haampie']
 
-    amdgpu_targets = (
-        'gfx803', 'gfx900', 'gfx906:xnack-', 'gfx908:xnack-',
-        'gfx90a:xnack-', 'gfx90a:xnack+', 'gfx1010', 'gfx1011', 'gfx1012', 'gfx1030'
-    )
+    amdgpu_targets = ROCmPackage.amdgpu_targets
+
     variant('amdgpu_target', values=auto_or_any_combination_of(*amdgpu_targets))
     variant('optimal', default=True,
             description='This option improves performance at the cost of increased binary \


### PR DESCRIPTION
This is a suggested change to https://github.com/spack/spack/pull/30582. That PR would allow building the ROCm math libraries for architectures besides the ones that are officially supported. I think that opens thrilling possibilities, but I want to ensure that users can still tell what amdgpu_target variants are officially supported.

I've compiled a list of the tested configurations for rocSOLVER and included them in this PR. The same `target_support_spec` would apply to rocBLAS as well. The list is used to check if any untested configurations have been specified. A warning is emitted when building for an architecture not explicitly supported by the library.

In theory, the exact same `target_support_spec` should apply to _all_ the ROCm math and communication libraries, but there is one exception. The introduction of target-id in ROCm 4.1 was hectic and confusing. As a result, some libraries adopted `gfx900` while others adopted `gfx900:xnack-`. The discrepancies were never reconciled. As such, all the ROCm libraries other than rocBLAS and rocSOLVER would use a slightly modified `target_support_spec`:

    target_support_spec = {
        'auto' : '@:',
        'gfx803': '@3.5.0:4.0.0',
        'gfx900': '@3.5.0:4.0.0',
        'gfx900:xnack-': '@4.1.0:4.5.2',
        'gfx906': '@3.5.0:4.0.0',
        'gfx906:xnack-': '@4.1.0:',
        'gfx908': '@4.0.0',
        'gfx908:xnack-': '@4.1.0:',
        'gfx90a:xnack-': '@4.3.0:',
        'gfx90a:xnack+': '@4.3.0:',
        'gfx1030': '@4.3.0:',
    }

@haampie @srekolam